### PR TITLE
fix(types): Align AcademicReport type with form validation schema

### DIFF
--- a/frontend/src/components/students/StudentForm.tsx
+++ b/frontend/src/components/students/StudentForm.tsx
@@ -255,7 +255,8 @@ const StudentForm: React.FC<StudentFormProps> = ({ student, onSave, onCancel, is
                 <FormInput label="Risk Level (1-5)" id="riskLevel" type="number" min="1" max="5" {...register('riskLevel', { valueAsNumber: true })} error={errors.riskLevel?.message as string} />
                 {/* FIX: Cast react-hook-form error message to string. */}
                  <FormSelect label="Transportation" id="transportation" {...register('transportation')} error={errors.transportation?.message as string} >
-                    {Object.values(TransportationType).map(s => <option key={s} value={s}>{s}</option>)}
+                    {/* FIX: Explicitly type `s` as string to prevent type inference issues. */}
+                    {Object.values(TransportationType).map((s: string) => <option key={s} value={s}>{s}</option>)}
                 </FormSelect>
                 {/* FIX: Cast react-hook-form error message to string. */}
                 <FormTextArea label="Child's Responsibilities" id="childResponsibilities" className="md:col-span-2" {...register('childResponsibilities')} error={errors.childResponsibilities?.message as string} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -195,7 +195,7 @@ export interface AcademicReport {
     gradeLevel: string;
     // FIX: Made subjectsAndGrades optional to match form usage.
     subjectsAndGrades?: string | null;
-    overallAverage: number;
+    overallAverage?: number | null;
     passFailStatus: 'Pass' | 'Fail';
     // FIX: Made teacherComments optional to match form usage.
     teacherComments?: string | null;


### PR DESCRIPTION
Resolves a build failure caused by a TypeScript type mismatch (TS2345) between the `AcademicReport` interface and its corresponding Zod validation schema.

The `overallAverage` field in `src/types.ts` was defined as a required `number`, while the form and validation logic correctly allowed it to be optional (`number | null | undefined`). This inconsistency prevented the application from compiling.

This commit updates the `AcademicReport` interface to correctly type `overallAverage` as `number | null | undefined`, bringing the type definition in sync with its actual usage and resolving the build error.