### PR TITLE
fix(api, transactions): Align transaction payload with backend serial…

### DIFF
--- a/frontend/src/components/AcademicReportForm.tsx
+++ b/frontend/src/components/AcademicReportForm.tsx
@@ -28,7 +28,7 @@ const AcademicReportForm: React.FC<AcademicReportFormProps> = ({
     const { register, handleSubmit, formState: { errors } } = useForm<AcademicReportFormData>({
         resolver: zodResolver(academicReportSchema),
         defaultValues: {
-            studentId: preselectedStudentId || initialData?.studentId || '',
+            studentId: preselectedStudentId || initialData?.student || '',
             reportPeriod: initialData?.reportPeriod || '',
             gradeLevel: initialData?.gradeLevel || '',
             subjectsAndGrades: initialData?.subjectsAndGrades || '',

--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -183,18 +183,18 @@ const StudentsPage: React.FC = () => {
         try {
             const aiFilters = await api.queryAIAssistantForStudentFilters(aiSearchQuery);
             
-            const { search, sponsor_name, ...restFilters } = aiFilters;
+            const { search, sponsorName, ...restFilters } = aiFilters;
             
             setSearchTerm(search || '');
 
             const finalFilters = { ...restFilters };
 
-            if (sponsor_name) {
-                const sponsor = sponsorLookup.find(s => s.name.toLowerCase().includes(sponsor_name.toLowerCase()));
+            if (sponsorName) {
+                const sponsor = sponsorLookup.find(s => s.name.toLowerCase().includes(sponsorName.toLowerCase()));
                 if (sponsor) {
                     finalFilters.sponsor = String(sponsor.id);
                 } else {
-                    showToast(`Sponsor "${sponsor_name}" not found.`, 'info');
+                    showToast(`Sponsor "${sponsorName}" not found.`, 'info');
                 }
             }
             

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -188,6 +188,15 @@ const prepareStudentData = (studentData: any) => {
     return data;
 };
 
+const prepareTransactionData = (data: any) => {
+    const snakeData = convertKeysToSnake(data);
+    if ('student_id' in snakeData) {
+        snakeData.student = snakeData.student_id;
+        delete snakeData.student_id;
+    }
+    return snakeData;
+};
+
 const queryAIAssistantForStudentFilters = async (query: string): Promise<any> => {
     try {
         const response = await apiClient('/ai-assistant/student-filters/', {
@@ -433,10 +442,14 @@ export const api = {
         const params = new URLSearchParams(dateRange);
         return apiClient(`/transactions/all/?${params.toString()}`);
     },
-    addTransaction: async (data: Omit<Transaction, 'id'>) => apiClient('/transactions/', { method: 'POST', body: JSON.stringify(convertKeysToSnake(data)) }),
+    addTransaction: async (data: Omit<Transaction, 'id'>) => {
+        const payload = prepareTransactionData(data);
+        return apiClient('/transactions/', { method: 'POST', body: JSON.stringify(payload) });
+    },
     updateTransaction: async (data: Transaction) => {
         const { id, ...rest } = data;
-        return apiClient(`/transactions/${id}/`, { method: 'PATCH', body: JSON.stringify(convertKeysToSnake(rest)) });
+        const payload = prepareTransactionData(rest);
+        return apiClient(`/transactions/${id}/`, { method: 'PATCH', body: JSON.stringify(payload) });
     },
     deleteTransaction: async (id: string) => apiClient(`/transactions/${id}/`, { method: 'DELETE' }),
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -189,7 +189,7 @@ export interface Student {
 
 export interface AcademicReport {
     id: string;
-    studentId: string;
+    student: string; // Renamed from studentId to match backend serializer
     studentName?: string; // Added for convenience
     reportPeriod: string;
     gradeLevel: string;


### PR DESCRIPTION
…izer

This commit corrects a data contract mismatch between the frontend and the backend for creating and updating transactions.

The backend TransactionSerializer expects the key student for associating a transaction with a student record during write operations. However, the frontend was sending studentId, which our case-converter utility turned into student_id.

To resolve this, a transformation function has been added to the API client (api.ts). This function intercepts outgoing transaction data, renames the student_id field to student, and ensures the payload matches the backend's expectation. This fixes the bug where student associations on transactions were not being saved correctly.