### PR TITLE
fix(types): Resolve build failure from incorrect AcademicReport type

### DIFF
--- a/frontend/src/components/students/StudentDetailView.tsx
+++ b/frontend/src/components/students/StudentDetailView.tsx
@@ -15,6 +15,7 @@ import Button from '@/components/ui/Button.tsx';
 import Badge from '../ui/Badge.tsx';
 import Tabs, { Tab } from '@/components/ui/Tabs.tsx';
 import { usePermissions } from '@/contexts/AuthContext.tsx';
+import { AcademicReportFormData } from '../schemas/academicReportSchema.ts';
 
 interface StudentDetailViewProps {
     student: Student;
@@ -64,10 +65,11 @@ const StudentDetailView: React.FC<StudentDetailViewProps> = ({
         }, 100);
     };
 
-    const handleSaveAcademicReport = async (reportData: Omit<AcademicReport, 'id' | 'studentId' | 'studentName'>) => {
+    const handleSaveAcademicReport = async (formData: AcademicReportFormData) => {
         setIsSaving(true);
         try {
-            await api.addAcademicReport(student.studentId, reportData);
+            const { studentId, ...reportData } = formData;
+            await api.addAcademicReport(studentId, reportData);
             showToast('Academic report added!', 'success');
             setModal(null);
             onDataChange();
@@ -246,7 +248,7 @@ const StudentDetailView: React.FC<StudentDetailViewProps> = ({
                 <Modal isOpen={true} onClose={() => setModal(null)} title="Add Academic Report">
                     <AcademicReportForm 
                         studentId={student.studentId}
-                        onSave={(data) => handleSaveAcademicReport(data)} 
+                        onSave={handleSaveAcademicReport} 
                         onCancel={() => setModal(null)}
                         isSaving={isSaving}
                     />

--- a/frontend/src/pages/AcademicsPage.tsx
+++ b/frontend/src/pages/AcademicsPage.tsx
@@ -1,5 +1,6 @@
 
 
+
 import React, { useState, useEffect, useCallback } from 'react';
 import { api } from '../services/api.ts';
 import { AcademicReport, PaginatedResponse } from '../types.ts';
@@ -70,7 +71,8 @@ const AcademicsPage: React.FC = () => {
         try {
             const { studentId, ...reportData } = formData;
             if (modalState === 'edit' && selectedReport) {
-                await api.updateAcademicReport(selectedReport.id, reportData);
+                const payload = { ...reportData, student: selectedReport.student };
+                await api.updateAcademicReport(selectedReport.id, payload);
                 showToast('Report updated successfully!', 'success');
             } else {
                 await api.addAcademicReport(studentId, reportData);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -429,10 +429,10 @@ export const api = {
     },
 
     // Academic Report Endpoints
-    addAcademicReport: async (studentId: string, report: Omit<AcademicReport, 'id' | 'studentId' | 'studentName'>) => {
+    addAcademicReport: async (studentId: string, report: Omit<AcademicReport, 'id' | 'student' | 'studentName'>) => {
         return apiClient(`/students/${studentId}/academic-reports/`, { method: 'POST', body: JSON.stringify(convertKeysToSnake(report)) });
     },
-    updateAcademicReport: async (reportId: string, updatedReportData: Omit<AcademicReport, 'id' | 'studentId' | 'studentName'>): Promise<AcademicReport> => {
+    updateAcademicReport: async (reportId: string, updatedReportData: Partial<Omit<AcademicReport, 'id' | 'studentName'>>): Promise<AcademicReport> => {
         return apiClient(`/academic-reports/${reportId}/`, { method: 'PATCH', body: JSON.stringify(convertKeysToSnake(updatedReportData)) });
     },
     deleteAcademicReport: async (reportId: string) => apiClient(`/academic-reports/${reportId}/`, { method: 'DELETE' }),


### PR DESCRIPTION
The deployment build was failing due to a TypeScript compilation error. The error indicated that payloads for creating and updating academic reports were missing the required student property.

This was caused by a type mismatch between the AcademicReport interface, which uses a student: string field, and the API service function signatures in api.ts, which were incorrectly typed to handle a studentId property.

This commit resolves the issue by:

Correcting the type signatures in src/services/api.ts for academic report functions to align with the AcademicReport model. Updating the data payloads in AcademicsPage.tsx and StudentDetailView.tsx to correctly structure the data before sending it to the API, resolving the type errors.