### PR TITLE
refactor(api, students): Improve token refresh and PDF generation reliability

### DIFF
--- a/frontend/src/components/students/StudentDetailView.tsx
+++ b/frontend/src/components/students/StudentDetailView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Student, FollowUpRecord } from '@/types.ts';
 import Modal from '@/components/Modal.tsx';
 import { EditIcon, TrashIcon, DocumentAddIcon, ArrowUpIcon, ArrowDownIcon, UserIcon } from '@/components/Icons.tsx';
@@ -56,14 +56,19 @@ const StudentDetailView: React.FC<StudentDetailViewProps> = ({
 
     const handleDownloadPdf = (record: FollowUpRecord) => {
         setRecordForPdf(record);
-        setTimeout(() => {
-            const studentName = record.childName.replace(/\s+/g, '-');
-            const date = new Date(record.dateOfFollowUp).toISOString().split('T')[0];
-            generatePdf(`Follow-Up-Report-${studentName}-${date}`).finally(() => {
-                setRecordForPdf(null);
-            });
-        }, 100);
     };
+    
+    // Use an effect to generate the PDF after the state has updated and the component has rendered.
+    // This avoids race conditions with the off-screen rendering.
+    useEffect(() => {
+        if (recordForPdf && printableRef.current) {
+            const studentName = recordForPdf.childName.replace(/\s+/g, '-');
+            const date = new Date(recordForPdf.dateOfFollowUp).toISOString().split('T')[0];
+            generatePdf(`Follow-Up-Report-${studentName}-${date}`).finally(() => {
+                setRecordForPdf(null); // Reset after generation is complete
+            });
+        }
+    }, [recordForPdf, generatePdf]);
 
     const handleSaveAcademicReport = async (formData: AcademicReportFormData) => {
         setIsSaving(true);


### PR DESCRIPTION
- Refactors the API client's token refresh queue to be fully type-safe, removing the need for `any` casting and improving robustness. The new implementation uses a queue of promise resolvers and rejectors for cleaner asynchronous flow.

- Fixes a potential race condition in student follow-up PDF generation by replacing an unreliable `setTimeout` with a `useEffect` hook. This ensures the printable component is rendered before the PDF generation is triggered, making the feature more stable.