### PR TITLE
fix(build): Resolve TypeScript errors in PageActions component

### DIFF
--- a/frontend/src/components/layout/PageActions.tsx
+++ b/frontend/src/components/layout/PageActions.tsx
@@ -22,16 +22,15 @@ const PageActions: React.FC<PageActionsProps> = ({ children }) => {
             return null;
         }
         
-        // FIX: Cast child.props to access properties without TypeScript errors.
-        // This is necessary because TypeScript doesn't know the specific props of the children components.
         const props = child.props as { children?: ReactNode, icon?: ReactNode, onClick: () => void, variant?: string };
 
-        // This check ensures we only process components that look like our Button
-        if (!props.children) {
+        // Ensure we only process buttons with simple string/number labels
+        if (typeof props.children !== 'string' && typeof props.children !== 'number') {
             return null;
         }
+        
         return {
-            label: props.children,
+            label: String(props.children), // Ensure the label is a string
             icon: props.icon,
             onClick: props.onClick,
             className: props.variant === 'danger' ? 'text-danger' : '',


### PR DESCRIPTION
This commit fixes two critical TypeScript errors (TS2533 and TS2322) in the `PageActions` component that were causing the build process to fail.

The root cause of the issue was that the component was making unsafe assumptions about the type of its `children`. It expected the `children` of the button components passed to it to be a simple `string`, but the actual type is a broader `ReactNode`. This led to a type mismatch when creating the `items` prop for the `ActionDropdown`.

The fix introduces type guards to:
1.  Safely handle cases where a child might not be a valid React element.
2.  Ensure that only children with simple `string` or `number` content are processed for the dropdown menu.
3.  Explicitly convert the label to a string to satisfy the `ActionItem` type definition.

This change makes the component more robust, ensures type safety, and resolves the build failure.