### PR TITLE
feat(notifications): Replace debug log with user-facing notification center

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,8 +14,7 @@ import Header from '@/components/layout/Header.tsx';
 import Sidebar from '@/components/layout/Sidebar.tsx';
 import { SkeletonTable } from './components/SkeletonLoader.tsx';
 import AIAssistant from './components/AIAssistant.tsx';
-import { GlobalNotificationProvider } from './contexts/GlobalNotificationProvider.tsx';
-import DebugEventLogger from './components/debug/DebugEventLogger.tsx';
+import { NotificationProvider } from './contexts/NotificationContext.tsx';
 import { ThemeProvider } from './contexts/ThemeContext.tsx';
 import { AuthProvider } from './contexts/AuthContext.tsx';
 import { SettingsProvider } from './contexts/SettingsContext.tsx';
@@ -95,8 +94,8 @@ const AppContent: React.FC = () => {
 const App: React.FC = () => (
     <HashRouter>
         <ThemeProvider>
-            <UIProvider>
-                <GlobalNotificationProvider>
+            <NotificationProvider>
+                <UIProvider>
                     <AuthProvider>
                         <Routes>
                             <Route path="/login" element={<LoginPage />} />
@@ -117,10 +116,9 @@ const App: React.FC = () => (
                             </Route>
                         </Routes>
                         <Toast />
-                        <DebugEventLogger />
                     </AuthProvider>
-                </GlobalNotificationProvider>
-            </UIProvider>
+                </UIProvider>
+            </NotificationProvider>
         </ThemeProvider>
     </HashRouter>
 );

--- a/frontend/src/components/NotificationCenter.tsx
+++ b/frontend/src/components/NotificationCenter.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useRef } from 'react';
+import { useNotification, AppNotification } from '@/contexts/NotificationContext.tsx';
+import { ErrorIcon, SuccessIcon } from '@/components/Icons.tsx';
+
+interface NotificationCenterProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const NotificationCenter: React.FC<NotificationCenterProps> = ({ isOpen, onClose }) => {
+    const { notifications, clearNotifications, markAllAsRead } = useNotification();
+    const prevIsOpen = useRef(isOpen);
+
+    useEffect(() => {
+        // When the panel is opened, mark all notifications as read.
+        if (!prevIsOpen.current && isOpen) {
+            markAllAsRead();
+        }
+        prevIsOpen.current = isOpen;
+    }, [isOpen, markAllAsRead]);
+
+
+    const typeClasses: Record<AppNotification['type'], { bg: string, text: string, icon: React.ReactNode }> = {
+        success: { bg: 'bg-success/10', text: 'text-success', icon: <SuccessIcon className="w-5 h-5" /> },
+        error: { bg: 'bg-danger/10', text: 'text-danger', icon: <ErrorIcon className="w-5 h-5" /> },
+        info: { bg: 'bg-primary/10', text: 'text-primary', icon: <SuccessIcon className="w-5 h-5" /> },
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="absolute right-0 mt-2 w-80 sm:w-96 rounded-lg border border-stroke bg-white shadow-lg dark:border-strokedark dark:bg-box-dark z-50">
+            <div className="flex items-center justify-between py-3 px-4.5 border-b border-stroke dark:border-strokedark">
+                <h4 className="text-sm font-semibold text-black dark:text-white">Notifications</h4>
+                <button onClick={clearNotifications} className="text-xs text-primary hover:underline">Clear All</button>
+            </div>
+
+            <div className="flex h-96 flex-col overflow-y-auto">
+                {notifications.length === 0 ? (
+                    <div className="flex items-center justify-center h-full">
+                        <p className="text-sm text-body-color">No notifications yet.</p>
+                    </div>
+                ) : (
+                    notifications.map(notif => (
+                        <div key={notif.id} className={`flex items-start gap-2.5 py-3 px-4.5 hover:bg-gray-2 dark:hover:bg-box-dark-2 border-b border-stroke dark:border-strokedark ${!notif.isRead ? 'bg-primary/5' : ''}`}>
+                            <div className={`w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-full ${typeClasses[notif.type].bg}`}>
+                                <span className={typeClasses[notif.type].text}>{typeClasses[notif.type].icon}</span>
+                            </div>
+                            <div className="flex-1">
+                                <p className="text-sm text-black dark:text-white break-words">
+                                    {notif.message}
+                                </p>
+                                <p className="text-xs text-body-color">{notif.timestamp.toLocaleTimeString()}</p>
+                            </div>
+                        </div>
+                    ))
+                )}
+            </div>
+             <button onClick={onClose} className="w-full text-center py-2 text-sm text-primary border-t border-stroke dark:border-strokedark hover:bg-gray-2 dark:hover:bg-box-dark-2">
+                Close
+            </button>
+        </div>
+    );
+};
+
+export default NotificationCenter;

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -21,14 +21,14 @@ const Toast: React.FC = () => {
     const typeStyles: Record<string, { bg: string; icon: React.ReactNode }> = {
         success: { bg: 'bg-success', icon: <SuccessIcon className="w-6 h-6" /> },
         error: { bg: 'bg-danger', icon: <ErrorIcon className="w-6 h-6" /> },
-        info: { bg: 'bg-primary', icon: <SuccessIcon className="w-6 h-6" /> }, // Using SuccessIcon for info as well for visual consistency
+        info: { bg: 'bg-primary', icon: <SuccessIcon className="w-6 h-6" /> },
     };
 
     const styles = typeStyles[toast.type] || typeStyles.info;
 
     return (
         <div 
-            className={`fixed top-5 right-5 z-50 flex items-center px-6 py-4 rounded-lg shadow-lg text-white ${styles.bg}`}
+            className={`fixed top-5 right-5 z-[9999] flex items-center px-6 py-4 rounded-lg shadow-lg text-white ${styles.bg}`}
             role="alert"
         >
             <div className="mr-4">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,19 +1,21 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { MenuIcon, BugIcon } from '@/components/Icons.tsx';
-import NotificationCenter from '@/components/debug/NotificationCenter.tsx';
+import { MenuIcon, BellIcon } from '@/components/Icons.tsx';
+import NotificationCenter from '@/components/NotificationCenter.tsx';
 import { useUI } from '@/contexts/UIContext.tsx';
+import { useNotification } from '@/contexts/NotificationContext.tsx';
 
 const Header: React.FC = () => {
     const { isSidebarOpen, toggleSidebar } = useUI();
-    const [isDebugOpen, setIsDebugOpen] = useState(false);
-    const debugRef = useRef<HTMLLIElement>(null);
+    const { unreadCount } = useNotification();
+    const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
+    const notificationRef = useRef<HTMLLIElement>(null);
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
-            if (debugRef.current && !debugRef.current.contains(event.target as Node)) {
+            if (notificationRef.current && !notificationRef.current.contains(event.target as Node)) {
                 const trigger = (event.target as HTMLElement).closest('button');
-                if (!trigger || trigger.id !== 'debug-trigger') {
-                     setIsDebugOpen(false);
+                if (!trigger || trigger.id !== 'notification-trigger') {
+                     setIsNotificationsOpen(false);
                 }
             }
         };
@@ -39,11 +41,20 @@ const Header: React.FC = () => {
                 
                 <div className="flex items-center gap-3 2xsm:gap-7">
                      <ul className="flex items-center gap-2 2xsm:gap-4">
-                        <li className="relative" ref={debugRef}>
-                            <button id="debug-trigger" onClick={() => setIsDebugOpen(p => !p)} className="p-2 rounded-full text-black dark:text-white hover:bg-gray-2 dark:hover:bg-box-dark-2">
-                                <BugIcon className="w-6 h-6" />
+                        <li className="relative" ref={notificationRef}>
+                            <button 
+                                id="notification-trigger" 
+                                onClick={() => setIsNotificationsOpen(p => !p)} 
+                                className="relative p-2 rounded-full text-black dark:text-white hover:bg-gray-2 dark:hover:bg-box-dark-2"
+                            >
+                                <BellIcon className="w-6 h-6" />
+                                {unreadCount > 0 && (
+                                    <span className="absolute top-0 right-0 h-4 w-4 rounded-full bg-danger text-white text-xs flex items-center justify-center">
+                                        {unreadCount}
+                                    </span>
+                                )}
                             </button>
-                            <NotificationCenter isOpen={isDebugOpen} onClose={() => setIsDebugOpen(false)} />
+                            <NotificationCenter isOpen={isNotificationsOpen} onClose={() => setIsNotificationsOpen(false)} />
                         </li>
                      </ul>
                 </div>


### PR DESCRIPTION
This commit refactors the notification system to provide a user-centric experience, replacing the developer-focused debug log with a persistent application notification center.

Key changes include:
- Replaced the "bug" icon in the header with a "bell" icon, which now shows a badge for unread notifications.
- The new notification panel provides a history of important user actions (e.g., "Student added successfully," "Task deleted").
- Consolidated the transient toast messages and the persistent notification list into a single, unified `NotificationContext`.
- All user actions that previously showed a toast now also populate the notification center automatically, ensuring a consistent experience.
- Removed the previous debug-only notification system to streamline the codebase.