### PR TITLE
fix(build): Resolve TypeScript errors in UI components

### DIFF
--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -3,11 +3,15 @@ import React from 'react';
 interface CardProps {
     children: React.ReactNode;
     className?: string;
+    onClick?: () => void;
 }
 
-export const Card: React.FC<CardProps> = ({ children, className }) => {
+export const Card: React.FC<CardProps> = ({ children, className, onClick }) => {
     return (
-        <div className={`rounded-lg border border-stroke bg-white shadow-md dark:border-strokedark dark:bg-box-dark ${className || ''}`}>
+        <div 
+            className={`rounded-lg border border-stroke bg-white shadow-md dark:border-strokedark dark:bg-box-dark ${className || ''}`}
+            onClick={onClick}
+        >
             {children}
         </div>
     );

--- a/frontend/src/components/users/UserSwipeView.tsx
+++ b/frontend/src/components/users/UserSwipeView.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, TouchEvent, useCallback } from 'react';
 import { AppUser, UserStatus, User } from '@/types.ts';
-import { formatDateForDisplay } from '@/utils/dateUtils.ts';
 import { ChevronLeftIcon, ChevronRightIcon, UserIcon, TrashIcon, KeyIcon } from '@/components/Icons.tsx';
 import EmptyState from '@/components/EmptyState.tsx';
 import Badge from '@/components/ui/Badge.tsx';


### PR DESCRIPTION
This commit resolves two TypeScript errors (TS2322 and TS6133) that were causing the application's build process to fail.

- **Card Component:** Updated the generic `Card` component in `src/components/ui/Card.tsx` to accept an `onClick` prop. This fixes a type error where the `SponsorCard` was attempting to pass a click handler to it.

- **UserSwipeView Component:** Removed an unused import of `formatDateForDisplay` from `src/components/users/UserSwipeView.tsx` to resolve the "declared but its value is never read" error.

These changes ensure component prop safety and allow the build to complete successfully.