### PR TITLE
fix: Resolve TypeScript build failures

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import { Student, Transaction, GovernmentFiling, Task, AcademicReport, FollowUpRecord, PaginatedResponse, StudentLookup, AuditLog, Sponsor, SponsorLookup, User, AppUser, Role, Permissions, DocumentType, StudentDocument, Sponsorship } from '../types.ts';
+import { Student, Transaction, GovernmentFiling, Task, AcademicReport, FollowUpRecord, PaginatedResponse, StudentLookup, AuditLog, Sponsor, SponsorLookup, User, AppUser, Role, Permissions, DocumentType, Sponsorship } from '../types.ts';
 import { convertKeysToCamel, convertKeysToSnake } from '../utils/caseConverter.ts';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://127.0.0.1:8000/api';
@@ -179,8 +179,6 @@ const apiClient = async (endpoint: string, options: RequestInit = {}): Promise<a
         throw error;
     }
 };
-
-type StudentFormData = Omit<Student, 'profilePhoto' | 'academicReports' | 'followUpRecords' | 'outOfProgramDate' | 'documents' | 'sponsorships'> & { profilePhoto?: File; outOfProgramDate?: string | null };
 
 const prepareStudentData = (studentData: any) => {
     const data = { ...studentData };
@@ -421,7 +419,7 @@ export const api = {
         
         return apiClient('/students/', { method: 'POST', body: formData });
     },
-    updateStudent: async (studentData: StudentFormData) => {
+    updateStudent: async (studentData: Partial<Student> & { studentId: string }) => {
         const { studentId, ...rest } = studentData;
         const preparedData = prepareStudentData(rest);
         const snakeCaseData = convertKeysToSnake(preparedData);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,5 @@
 
-import { StudentFormData } from './components/schemas/studentSchema.ts';
+
 export interface PaginatedResponse<T> {
     count: number;
     next: string | null;
@@ -218,6 +218,10 @@ export interface Student {
     followUpRecords?: FollowUpRecord[];
     documents?: StudentDocument[];
     sponsorships?: Sponsorship[];
+
+    // For import purposes
+    sponsorName?: string;
+    hasSponsorshipContract?: boolean;
 
     // Frontend-only fields for improved form logic
     primaryCaregiver?: PrimaryCaregiver;


### PR DESCRIPTION
The build was failing due to several strict TypeScript type errors. This commit addresses them as follows:

- Updates the `updateStudent` API client method to correctly handle partial updates. The previous type signature was too restrictive, causing errors when only a subset of student fields were being modified (e.g., from the document upload modal).

- Extends the `Student` interface to include optional `sponsorName` and `hasSponsorshipContract` fields. These are used during the bulk import process and were causing type assignment errors.

- Removes unused `StudentDocument` and `StudentFormData` type imports to clean up the code and resolve "unused variable" compiler errors.