### PR TITLE
fix: Resolve build error in student table configuration

### DIFF
--- a/frontend/src/config/studentTableConfig.tsx
+++ b/frontend/src/config/studentTableConfig.tsx
@@ -21,7 +21,7 @@ export const ALL_STUDENT_COLUMNS: ColumnConfig[] = [
     { id: 'guardianName', label: 'Guardian', renderCell: (s) => s.guardianName || 'N/A', },
     { id: 'studentStatus', label: 'Status', renderCell: (s) => <Badge type={s.studentStatus} />, },
     { id: 'sponsorshipStatus', label: 'Sponsorship', renderCell: (s) => <Badge type={s.sponsorshipStatus} />, },
-    { id: 'sponsorsCount', label: 'Sponsors', renderCell: (s) => s.sponsorsCount, },
+    { id: 'activeSponsorsCount', label: 'Sponsors', renderCell: (s) => s.sponsorships?.filter(sp => !sp.endDate).length || 0 },
 ];
 
 // The default set of columns and their order.
@@ -33,7 +33,6 @@ export const DEFAULT_STUDENT_COLUMNS_ORDER: (keyof Student | 'age')[] = [
   'age',
   'studentStatus',
   'sponsorshipStatus',
-  'sponsorsCount',
 ];
 
 export const getDefaultColumns = (): ColumnConfig[] => {


### PR DESCRIPTION
The build was failing due to TypeScript errors in `src/config/studentTableConfig.tsx`. The configuration was attempting to access and sort by a `sponsorsCount` property that does not exist on the `Student` type.

This commit replaces the erroneous `sponsorsCount` column with a new `activeSponsorsCount` column. The new implementation correctly calculates the number of active sponsors by filtering the `sponsorships` array for entries without an end date.

The invalid key has also been removed from the default column ordering array, resolving the final build error.