### PR TITLE
chore: Remove unused variables to fix build errors

### DIFF
--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -54,7 +54,6 @@ const StudentsPage: React.FC = () => {
     const { canCreate, canUpdate } = usePermissions('students');
     const [isAiSearching, setIsAiSearching] = useState(false);
     const [aiSearchQuery, setAiSearchQuery] = useState('');
-    const isMobile = useMediaQuery('(max-width: 767px)');
     const { studentTableColumns, studentViewMode, setStudentViewMode } = useSettings();
     const { isAiEnabled } = useSettings();
 

--- a/frontend/src/pages/UserManagementPage.tsx
+++ b/frontend/src/pages/UserManagementPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { api } from '@/services/api.ts';
-import { AppUser, UserStatus, User } from '@/types.ts';
+import { AppUser, UserStatus } from '@/types.ts';
 import { useNotification } from '@/contexts/NotificationContext.tsx';
 import { useTableControls } from '@/hooks/useTableControls.ts';
 import { SkeletonCard, SkeletonTable, SkeletonListItem } from '@/components/SkeletonLoader.tsx';


### PR DESCRIPTION
The TypeScript build was failing due to `noUnusedLocals` errors. This was caused by leftover variable declarations from the recent mobile UX refactoring.

This commit removes:
- The unused `isMobile` constant from `StudentsPage.tsx`.
- The unused `User` type import from `UserManagementPage.tsx`.

These changes are purely code cleanup and resolve the build failures.