### PR TITLE
fix: Remove unused useMediaQuery import from StudentsPage

### DIFF
--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -21,7 +21,6 @@ import { useSettings } from '@/contexts/SettingsContext.tsx';
 import BulkActionBar from '@/components/students/BulkActionBar.tsx';
 import { usePermissions } from '@/contexts/AuthContext.tsx';
 import PageActions from '@/components/layout/PageActions.tsx';
-import useMediaQuery from '@/hooks/useMediaQuery.ts';
 import StudentCard from '@/components/students/StudentCard.tsx';
 import ViewToggle from '@/components/ui/ViewToggle.tsx';
 import { usePaginatedData } from '@/hooks/usePaginatedData.ts';


### PR DESCRIPTION
The build was failing due to a TypeScript `noUnusedLocals` error (TS6133). The `useMediaQuery` hook was imported in `src/pages/StudentsPage.tsx` but was no longer being referenced in the component after recent refactoring.

This commit removes the unused import statement, resolving the build failure.