### PR TITLE
fix(students): Resolve build error on profile photo type check

### DIFF
--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -197,7 +197,7 @@ const StudentsPage: React.FC = () => {
         let payload = { ...studentData };
 
         if (!isOnline) {
-            if (payload.profilePhoto && payload.profilePhoto instanceof File) {
+            if (typeof payload.profilePhoto === 'object' && payload.profilePhoto && payload.profilePhoto instanceof File) {
                 showToast('Photo uploads are not available offline and will be ignored.', 'info');
                 delete payload.profilePhoto;
             }
@@ -237,7 +237,7 @@ const StudentsPage: React.FC = () => {
         let payload = { ...studentData };
 
         if (!isOnline) {
-            if (payload.profilePhoto && payload.profilePhoto instanceof File) {
+            if (typeof payload.profilePhoto === 'object' && payload.profilePhoto && payload.profilePhoto instanceof File) {
                 showToast('Photo uploads are not available offline and will be ignored.', 'info');
                 delete payload.profilePhoto;
             }


### PR DESCRIPTION
This commit fixes a critical TypeScript error that was causing the production build to fail during deployment.

The error occurred in the handleSaveCreateStudent and handleSaveUpdateStudent functions. An instanceof File check was being performed on the profilePhoto property without first verifying its type. When a user updated a student without changing an existing photo, this property would be a string (URL), leading to an invalid instanceof operation on a primitive type and causing the build to fail. The fix introduces a type guard (typeof payload.profilePhoto === 'object' && payload.profilePhoto !== null) before the instanceof File check. This ensures the check is only performed on valid objects.