### PR TITLE
fix(offline): Prevent crash on ID type mismatch after sync

### DIFF
--- a/frontend/src/components/sponsors/SponsorCard.tsx
+++ b/frontend/src/components/sponsors/SponsorCard.tsx
@@ -11,7 +11,7 @@ interface SponsorCardProps {
 
 const SponsorCard: React.FC<SponsorCardProps> = ({ sponsor }) => {
     const navigate = useNavigate();
-    const isPending = sponsor.id.startsWith('temp-');
+    const isPending = String(sponsor.id).startsWith('temp-');
 
     return (
         <Card

--- a/frontend/src/components/students/MobileStudentCard.tsx
+++ b/frontend/src/components/students/MobileStudentCard.tsx
@@ -21,7 +21,7 @@ const StatItem: React.FC<{ label: string; value: React.ReactNode }> = ({ label, 
 
 
 const MobileStudentCard: React.FC<MobileStudentCardProps> = ({ student, onViewProfile, actionItems, sponsorName }) => {
-    const isPending = student.studentId.startsWith('temp-');
+    const isPending = String(student.studentId).startsWith('temp-');
 
     return (
         <div className="bg-white dark:bg-box-dark rounded-lg border border-stroke dark:border-strokedark shadow-sm overflow-hidden">

--- a/frontend/src/pages/SponsorsPage.tsx
+++ b/frontend/src/pages/SponsorsPage.tsx
@@ -1,3 +1,4 @@
+
     import React, { useState, useEffect } from 'react';
     import { useNavigate } from 'react-router-dom';
     import { api } from '@/services/api.ts';
@@ -158,7 +159,7 @@
                                 ) : (
                                     <>
                                         {sponsors.map(sponsor => {
-                                            const isPending = sponsor.id.startsWith('temp-');
+                                            const isPending = String(sponsor.id).startsWith('temp-');
                                             return (
                                                 <MobileListItem
                                                     key={sponsor.id}
@@ -213,7 +214,7 @@
                                                 </thead>
                                                 <tbody>
                                                     {sponsors.map(sponsor => {
-                                                        const isPending = sponsor.id.startsWith('temp-');
+                                                        const isPending = String(sponsor.id).startsWith('temp-');
                                                         return (
                                                             <tr key={sponsor.id} className={!isPending ? "cursor-pointer" : ""} onClick={() => !isPending && navigate(`/sponsors/${sponsor.id}`)}>
                                                                 <td className="font-medium">

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -255,7 +255,7 @@ const TasksPage: React.FC = () => {
                 isMobile ? (
                     <div className="space-y-3">
                         {tasks.map((task) => {
-                            const isPending = task.id.startsWith('temp-');
+                            const isPending = String(task.id).startsWith('temp-');
                             return (
                                 <MobileListItem
                                     key={task.id}
@@ -293,7 +293,7 @@ const TasksPage: React.FC = () => {
                                 </thead>
                                 <tbody>
                                     {tasks.map((task) => {
-                                        const isPending = task.id.startsWith('temp-');
+                                        const isPending = String(task.id).startsWith('temp-');
                                         const actionItems = [];
                                         if (canUpdate && !isPending) {
                                             actionItems.push({ label: 'Edit', icon: <EditIcon className="w-4 h-4" />, onClick: () => setEditingTask(task) });


### PR DESCRIPTION
The application was crashing with a `TypeError: B.id.startsWith is not a function` when viewing lists containing recently synced items created while offline.

This occurred because offline-created records are assigned a temporary string ID (e.g., "temp-12345"). UI components use `id.startsWith('temp-')` to identify these pending-sync items. Upon successful synchronization, the server replaces this temporary ID with a permanent, numeric database ID.

On the next render, the UI would attempt to call the string method `.startsWith()` on the new numeric ID, causing the TypeError and crashing the component.

This commit resolves the issue by defensively coercing the `id` to a string (`String(id).startsWith(...)`) in all components where this check occurs. This ensures the logic works reliably for both temporary string IDs and permanent numeric IDs, preventing the crash and ensuring a smooth user experience.