### PR TITLE
fix(offline): Correct 'isPending' logic to prevent build failure

### DIFF
--- a/frontend/src/components/sponsors/SponsorCard.tsx
+++ b/frontend/src/components/sponsors/SponsorCard.tsx
@@ -11,7 +11,7 @@ interface SponsorCardProps {
 
 const SponsorCard: React.FC<SponsorCardProps> = ({ sponsor }) => {
     const navigate = useNavigate();
-    const isPending = sponsor.id && typeof sponsor.id === 'string' && sponsor.id.startsWith('temp-');
+    const isPending = String(sponsor.id).startsWith('temp-');
 
     return (
         <Card

--- a/frontend/src/pages/SponsorsPage.tsx
+++ b/frontend/src/pages/SponsorsPage.tsx
@@ -160,7 +160,7 @@
                                 ) : (
                                     <>
                                         {sponsors.map(sponsor => {
-                                            const isPending = sponsor.id && typeof sponsor.id === 'string' && sponsor.id.startsWith('temp-');
+                                            const isPending = String(sponsor.id).startsWith('temp-');
                                             return (
                                                 <MobileListItem
                                                     key={sponsor.id}
@@ -215,7 +215,7 @@
                                                 </thead>
                                                 <tbody>
                                                     {sponsors.map(sponsor => {
-                                                        const isPending = sponsor.id && typeof sponsor.id === 'string' && sponsor.id.startsWith('temp-');
+                                                        const isPending = String(sponsor.id).startsWith('temp-');
                                                         return (
                                                             <tr key={sponsor.id} className={!isPending ? "cursor-pointer" : ""} onClick={() => !isPending && navigate(`/sponsors/${sponsor.id}`)}>
                                                                 <td className="font-medium">

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -263,7 +263,7 @@ const TasksPage: React.FC = () => {
                 isMobile ? (
                     <div className="space-y-3">
                         {tasks.map((task) => {
-                            const isPending = task.id && typeof task.id === 'string' && task.id.startsWith('temp-');
+                            const isPending = String(task.id).startsWith('temp-');
                             return (
                                 <MobileListItem
                                     key={task.id}
@@ -301,7 +301,7 @@ const TasksPage: React.FC = () => {
                                 </thead>
                                 <tbody>
                                     {tasks.map((task) => {
-                                        const isPending = task.id && typeof task.id === 'string' && task.id.startsWith('temp-');
+                                        const isPending = String(task.id).startsWith('temp-');
                                         const actionItems = [];
                                         if (canUpdate && !isPending) {
                                             actionItems.push({ label: 'Edit', icon: <EditIcon className="w-4 h-4" />, onClick: () => setEditingTask(task) });


### PR DESCRIPTION
The build process was failing due to a TypeScript error (`Type 'boolean | ""' is not assignable to type 'boolean | undefined'`) in `TasksPage.tsx`.

This was a regression introduced by a recent change intended to make the 'pending sync' ID check more robust. The updated logic could incorrectly evaluate to an empty string (`""`) when an item's ID was a number (i.e., after being synced from offline). This non-boolean value was then passed to a component prop expecting a boolean (e.g., `disabled`), causing the type error and breaking the build.

This commit reverts the logic to the `String(id).startsWith('temp-')` pattern. This approach is type-safe, consistently returns a boolean value, and resolves the build failure.

The fix has been applied consistently across `TasksPage`, `SponsorsPage`, and `SponsorCard` to prevent similar issues.