### PR TITLE
fix(app): Correct race condition on error and fix navigation bug

### DIFF
--- a/frontend/src/components/sponsors/SponsorSwipeView.tsx
+++ b/frontend/src/components/sponsors/SponsorSwipeView.tsx
@@ -31,7 +31,7 @@ const SponsorSwipeView: React.FC<SponsorSwipeViewProps> = ({ sponsors, isLoading
 
     const goToPrev = useCallback(() => {
         if (currentIndex > 0) {
-            setCurrentIndex(prev => prev + 1);
+            setCurrentIndex(prev => prev - 1);
         }
     }, [currentIndex]);
 

--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -280,6 +280,9 @@ const StudentsPage: React.FC = () => {
     const handleDeleteStudent = async (studentId: string, fromDetailView: boolean = false) => {
         if(!window.confirm('Are you sure you want to delete this student? This will also remove all associated records.')) return;
         
+        const studentToDelete = studentsList.find(s => s.studentId === studentId);
+        if (!studentToDelete) return;
+
         // Optimistic UI update
         setStudentsList(prev => prev.filter(s => s.studentId !== studentId));
 
@@ -304,7 +307,8 @@ const StudentsPage: React.FC = () => {
             refetchListData();
         } catch (error: any) {
             showToast(error.message || 'Failed to delete student.', 'error');
-            setStudentsList(paginatedData?.results || []);
+            // FIX: Revert the change safely using a functional update instead of stale data.
+            setStudentsList(prev => [...prev, studentToDelete].sort((a,b) => a.firstName.localeCompare(b.firstName)));
         }
     };
 


### PR DESCRIPTION
This commit addresses two bugs discovered during an audit for issues that are more likely to manifest in a live environment with real network latency.

1.  **Stale State on Student Deletion Error:** The `handleDeleteStudent` function used an optimistic UI update. If the subsequent API call failed, the error-handling logic would revert the student list to a potentially stale version of the data captured at render time. This could cause other state changes (like sorting or filtering) to be lost.

    The fix replaces this with a functional state update (`setStudentsList(prev => ...)`), which safely adds the student back to the *current* state, preserving data integrity during error recovery.

2.  **Sponsor Swipe Navigation Bug:** In the `SponsorSwipeView` component, the `goToPrev` function for navigating to the previous sponsor contained a logic error, causing it to increment the index instead of decrementing it. This made the "previous" button behave identically to the "next" button. The logic has been corrected to properly decrement the index.